### PR TITLE
fix illegal presets error on line #40 of file

### DIFF
--- a/settings/presets_settings.php
+++ b/settings/presets_settings.php
@@ -31,7 +31,7 @@ $page = new admin_settingpage('theme_handlebar_presets', get_string('presets_set
 $name = 'theme_handlebar/preset';
 $title = get_string('preset', 'theme_handlebar');
 $description = get_string('preset_desc', 'theme_handlebar');
-$presetchoices = '';
+$presetchoices = Array();
 // Add preset files from theme preset folder.
 $iterator = new DirectoryIterator($CFG->dirroot . '/theme/handlebar/scss/preset/');
 foreach ($iterator as $presetfile) {


### PR DESCRIPTION
current parameter is set as string, if pre-set as Array error is removed.